### PR TITLE
BUG - Missing required "width" property.

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -10,11 +10,14 @@ const About: React.FC = () => {
         </h2>
         <div className="grid lg:grid-cols-1 md:grid-cols-1 sm:grid-cols-1 gap-8 text-center mt-12">
           <div className="bg-white py-4 px-2 shadow-md rounded-lg hoer:scale-110 transition-all duration-500">
-            <Image
-              src={'/images/profile.jpg'}
-              className="w-36 h-36 rounded-full inline-block"
-              alt="Profile"
-            />
+            <div className="relative w-36 h-36 inline-block">
+              <Image
+                src={'/images/profile.jpg'}
+                className="rounded-full"
+                alt="Profile"
+                fill
+              />
+            </div>
             <div className="mt-4">
               <h4 className="text-gray-800 text-base font-bold">
                 Donovan Lindsay


### PR DESCRIPTION
# Description

Encountered the following error:

<img width="350" alt="Screenshot 2025-03-16 at 16 00 09" src="https://github.com/user-attachments/assets/9e76546d-47c9-487d-ad27-807793f03486" />

Similar to the following stack overflow issue: https://stackoverflow.com/questions/75781160/next-image-component-gives-error-missing-required-width-property-when-runni

By wrapping the image, with the fill property set, in a div and setting the width and height on the div container along with a relative position as outlined in the [documentation](https://nextjs.org/docs/app/api-reference/components/image#fill) the error was resolved.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


